### PR TITLE
Update and rename shared.lua to discord_muter.lua

### DIFF
--- a/lua/autorun/discord_muter.lua
+++ b/lua/autorun/discord_muter.lua
@@ -1,8 +1,10 @@
 AddCSLuaFile();
-include("discord/utils/logging.lua");
-include("discord/utils/messaging.lua");
-include("discord/utils/discord_connection.lua");
-include("discord/utils/http.lua");
+if Server then
+  include("discord/utils/logging.lua");
+  include("discord/utils/messaging.lua");
+  include("discord/utils/discord_connection.lua");
+  include("discord/utils/http.lua");
+end
 resource.AddFile("materials/icon256/mute.png");
 
 if (CLIENT) then


### PR DESCRIPTION
Namespace issue with shared.lua. Other addons using the same name will overwrite the file causing the addon not to work at all.

"Include" should be only Serverside as it throws errors on clientside as they cant open / dont need these luafiles. Not doing it serverside only causes 4x errors each time the files is loaded:

[ERROR] Couldn't include file 'discord\utils\logging.lua' - File not found or is empty 
[ERROR] Couldn't include file 'discord\utils\messaging.lua' - File not found or is empty 
[ERROR] Couldn't include file 'discord\utils\discord_connection.lua' - File not found or is empty 
[ERROR] Couldn't include file 'discord\utils\http.lua' - File not found or is empty 